### PR TITLE
Task 2. Add internal util functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+bin/
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+BIN_DIR = bin
+
+.PHONY: run, test, build, clean, all
+
+run:
+	go run cmd/ova-journey-api/main.go
+
+test:
+	go test ./...
+
+build:
+	go build -o $(BIN_DIR)/main cmd/ova-journey-api/main.go
+
+clean:
+	rm -rf $(BIN_DIR)
+
+all: test build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # ova-journey-api
-ova-journey-api
+
+### Commands
++ ```make run```- run the application
++ ```make build``` - build the application into `bin` directory
++ ```make clean``` - clean from binary builds, delete `bin` directory
++ ```make test``` - run all tests
++ ```make all``` - run all tests, then build the application 
+
+
+

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ozonva/ova-journey-api
 
 go 1.16
+
+require github.com/stretchr/testify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/utils/filter_slice.go
+++ b/internal/utils/filter_slice.go
@@ -1,0 +1,26 @@
+package utils
+
+// FilterSlice returns new slice with elements from original slice not presented in exclusion slice
+func FilterSlice(slice []string, excluded []string) []string {
+	if slice == nil {
+		return nil
+	}
+
+	var filteredSlice = make([]string, 0, len(slice))
+
+	if len(slice) > 0 {
+		// prepare filtration map
+		var excludedMap = make(map[string]struct{}, len(excluded))
+		for _, value := range excluded {
+			excludedMap[value] = struct{}{}
+		}
+		// filter slice by map
+		for _, value := range slice {
+			if _, found := excludedMap[value]; !found {
+				filteredSlice = append(filteredSlice, value)
+			}
+		}
+	}
+
+	return filteredSlice
+}

--- a/internal/utils/filter_slice.go
+++ b/internal/utils/filter_slice.go
@@ -6,19 +6,21 @@ func FilterSlice(slice []string, excluded []string) []string {
 		return nil
 	}
 
+	if len(slice) == 0 {
+		return []string{}
+	}
+
 	var filteredSlice = make([]string, 0, len(slice))
 
-	if len(slice) > 0 {
-		// prepare filtration map
-		var excludedMap = make(map[string]struct{}, len(excluded))
-		for _, value := range excluded {
-			excludedMap[value] = struct{}{}
-		}
-		// filter slice by map
-		for _, value := range slice {
-			if _, found := excludedMap[value]; !found {
-				filteredSlice = append(filteredSlice, value)
-			}
+	// prepare filtration map
+	var excludedMap = make(map[string]struct{}, len(excluded))
+	for _, value := range excluded {
+		excludedMap[value] = struct{}{}
+	}
+	// filter slice by map
+	for _, value := range slice {
+		if _, found := excludedMap[value]; !found {
+			filteredSlice = append(filteredSlice, value)
 		}
 	}
 

--- a/internal/utils/filter_slice_test.go
+++ b/internal/utils/filter_slice_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFilterSlice(t *testing.T) {
+	var testTable = []struct {
+		slice    []string
+		excluded []string
+		result   []string
+	}{
+		{
+			slice:    []string{"ova", "journey", "api"},
+			excluded: []string{"journey"},
+			result:   []string{"ova", "api"},
+		},
+		{
+			slice:    []string{"ova", "journey", "api"},
+			excluded: []string{"another"},
+			result:   []string{"ova", "journey", "api"},
+		},
+		{
+			slice:    []string{"ova", "journey", "api"},
+			excluded: nil,
+			result:   []string{"ova", "journey", "api"},
+		},
+		{
+			slice:    nil,
+			excluded: nil,
+			result:   nil,
+		},
+		{
+			slice:    []string{},
+			excluded: nil,
+			result:   []string{},
+		},
+	}
+
+	for _, testCase := range testTable {
+		result := FilterSlice(testCase.slice, testCase.excluded)
+
+		assert.Equal(t, testCase.result, result)
+	}
+}

--- a/internal/utils/split_slice_to_chunk.go
+++ b/internal/utils/split_slice_to_chunk.go
@@ -17,7 +17,7 @@ func SplitSliceToChunk(slice []int, chunkSize int) ([][]int, error) {
 		chunksCount++
 	}
 
-	var chunks = make([][]int, chunksCount, chunksCount)
+	var chunks = make([][]int, chunksCount)
 	var start, end = 0, 0
 	for i := 0; i < chunksCount; i++ {
 		start = end

--- a/internal/utils/split_slice_to_chunk.go
+++ b/internal/utils/split_slice_to_chunk.go
@@ -1,0 +1,31 @@
+package utils
+
+import "errors"
+
+// SplitSliceToChunk - split slice to chunks of equal size (chunkSize), except last chunk that contains last elements of slice
+func SplitSliceToChunk(slice []int, chunkSize int) ([][]int, error) {
+	if slice == nil {
+		return nil, errors.New("slice cannot be nil")
+	}
+
+	if chunkSize < 1 {
+		return nil, errors.New("chunk size must be greater then zero")
+	}
+
+	var chunksCount = len(slice) / chunkSize
+	if len(slice)%chunkSize > 0 {
+		chunksCount++
+	}
+
+	var chunks = make([][]int, chunksCount, chunksCount)
+	var start, end = 0, 0
+	for i := 0; i < chunksCount; i++ {
+		start = end
+		end += chunkSize
+		if end > len(slice) {
+			end = len(slice)
+		}
+		chunks[i] = slice[start:end]
+	}
+	return chunks, nil
+}

--- a/internal/utils/split_slice_to_chunk_test.go
+++ b/internal/utils/split_slice_to_chunk_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSplitSliceToChunk(t *testing.T) {
+	var testTable = []struct {
+		slice     []int
+		chunkSize int
+		result    [][]int
+	}{
+		{
+			slice:     []int{1, 2},
+			chunkSize: 1,
+			result:    [][]int{[]int{1}, []int{2}},
+		},
+		{
+			slice:     []int{1, 2, 3, 4, 5},
+			chunkSize: 2,
+			result:    [][]int{[]int{1, 2}, []int{3, 4}, []int{5}},
+		},
+		{
+			slice:     nil,
+			chunkSize: 2,
+			result:    nil,
+		},
+		{
+			slice:     []int{1, 2, 3, 4, 5},
+			chunkSize: -1,
+			result:    nil,
+		},
+		{
+			slice:     []int{},
+			chunkSize: 1,
+			result:    [][]int{},
+		},
+		{
+			slice:     []int{1, 2},
+			chunkSize: 10,
+			result:    [][]int{[]int{1, 2}},
+		},
+	}
+
+	for _, testCase := range testTable {
+		result, _ := SplitSliceToChunk(testCase.slice, testCase.chunkSize)
+
+		assert.Equal(t, testCase.result, result)
+	}
+}

--- a/internal/utils/swap_map_key_value.go
+++ b/internal/utils/swap_map_key_value.go
@@ -1,0 +1,22 @@
+package utils
+
+import "errors"
+
+// SwapMapKeyValue returns new map by swapping keys and values in original map
+// If original map contains repeated values returns error
+func SwapMapKeyValue(sourceMap map[int]string) (map[string]int, error) {
+	if sourceMap == nil {
+		return nil, nil
+	}
+
+	var destMap map[string]int = make(map[string]int, len(sourceMap))
+
+	for key, value := range sourceMap {
+		if _, found := destMap[value]; found {
+			return nil, errors.New("sourceMap values must be unique to swap")
+		}
+		destMap[value] = key
+	}
+
+	return destMap, nil
+}

--- a/internal/utils/swap_map_key_value.go
+++ b/internal/utils/swap_map_key_value.go
@@ -9,7 +9,7 @@ func SwapMapKeyValue(sourceMap map[int]string) (map[string]int, error) {
 		return nil, nil
 	}
 
-	var destMap map[string]int = make(map[string]int, len(sourceMap))
+	destMap := make(map[string]int, len(sourceMap))
 
 	for key, value := range sourceMap {
 		if _, found := destMap[value]; found {

--- a/internal/utils/swap_map_key_value_test.go
+++ b/internal/utils/swap_map_key_value_test.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSwapMapKeyValue(t *testing.T) {
+	var testTable = []struct {
+		sourceMap map[int]string
+		destMap   map[string]int
+	}{
+		{
+			sourceMap: map[int]string{
+				1: "ova",
+				2: "journey",
+				3: "api",
+			},
+			destMap: map[string]int{
+				"ova":     1,
+				"journey": 2,
+				"api":     3,
+			},
+		},
+		{
+			sourceMap: map[int]string{
+				1: "ova",
+				2: "ova",
+				3: "api",
+			},
+			destMap: nil,
+		},
+		{
+			sourceMap: nil,
+			destMap:   nil,
+		},
+	}
+
+	for _, testCase := range testTable {
+		result, _ := SwapMapKeyValue(testCase.sourceMap)
+
+		assert.Equal(t, testCase.destMap, result)
+	}
+}


### PR DESCRIPTION
В пакете internal/utils вашего репозитория нужно реализовать экспортируемые функции для

- [x] Разделение на слайса на батчи - исходный слайс конвертировать в слайс слайсов - чанки одинкового размера (кроме последнего)
- [x] Обратный ключ - происходит конвертация отображения (“ключ-значение“) в отображение (“значение-ключ“)
- [x] Фильтрация по захордкоженному списку - нужно отфильтровать входной слайс по критерию отсутствия элемента в захардкоженном списке

В качестве типов сейчас будем использовать встроенные типы: целые числа или строковые